### PR TITLE
共通処理側のパンくずリスト生成処理の改善

### DIFF
--- a/public/common/Layout/init.php
+++ b/public/common/Layout/init.php
@@ -33,17 +33,46 @@ function StrExtraction($str, $target, $state) {
 }
 // パンくずリストの生成 (完成・検証後にSetting.phpに移動)
 $dir = scandir(__DIR__);
-$realPath = getcwd();
-$currentDir = $realPath;
+$currentDir = $base->GetURI();
 $count = 0;
 while (1) {
+    // タイトル：ディレクトリ名、パス：URL
     $breadCrumbList[$count] = array();
     $breadCrumbList[$count]['title'] = basename($currentDir);
-    $breadCrumbList[$count]['path'] = $currentDir;
-    if (basename($currentDir) === $domain) {
+    $breadCrumbList[$count]['path'] = $domain.$currentDir;
+    if ($currentDir === DIRECTORY_SEPARATOR) {
+        // ルートディレクトリはそれぞれの設定をドメイン名に上書き
+        // (Linux環境はROOT定数, Windows環境は円マーク)
+        $breadCrumbList[$count]['title'] = $domain;
+        $breadCrumbList[$count]['path'] = $domain;
         break;
     } else {
         $count++;
     }
     $currentDir = dirname($currentDir);
+}
+
+// HTML出力用に調整
+$create = new CustomTagCreate();
+$breadCrumbList_ = array();
+foreach ($breadCrumbList as $bread) {
+    $breadCrumbList_[] = $create->SetHref($http.$bread['path'], $bread['title'], 'breadCrumbList');
+}
+$breadCrumbList_ = array_reverse($breadCrumbList_);
+$breadCrumbList = $breadCrumbList_;
+unset($breadCrumbList_);
+
+$arrow = new HTMLClass(true);
+$arrow->TagSet('span', '->', 'arrow', true);
+$arrow = $arrow->TagExec();
+
+// 配列を順に出力する (パンくず出力用)
+function ViewArray($ary, $arow="\t") {
+    foreach ($ary as $_elm => $_ary) {
+        // 配列の末尾では間の文字(矢印)は消す
+        if ($_elm === (count($ary) - 1)) {
+            $arow = '';
+        }
+        echo $ary[$_elm]. $arow;
+    }
 }

--- a/public/custom_base/Layout/init.php
+++ b/public/custom_base/Layout/init.php
@@ -31,7 +31,7 @@ function StrExtraction($str, $target) {
 
 // パンくずリストの生成 (完成・検証後にSetting.phpに移動)
 $dir = scandir(__DIR__);
-$currentDir = PublicSetting\GetURI();
+$currentDir = $base->GetURI();
 $count = 0;
 while (1) {
     // タイトル：ディレクトリ名、パス：URL


### PR DESCRIPTION
今までは、リモート↔ローカルでディレクトリ名が違うため、どちらかに移動させると動かなくなる不具合があった。
そのため処理にドメイン名(ディレクトリ名)を使用しないように修正し、
どちら側でも対応できるようにした。