### PR TITLE
404ページに遷移した際の処理の見直し

### DIFF
--- a/common/error/404/index.php
+++ b/common/error/404/index.php
@@ -1,10 +1,4 @@
-<!DOCTYPE html>
 <?php
-if (!isset($_SESSION)) {
-    session_start();
-}
-// 初期設定を記述
-$homepageTitle = htmlspecialchars(basename(__DIR__));
 // アクセスしたページが既存ページの大文字・小文字の違いであれば、既存ページに遷移
 $pageList = scandir(dirname(__DIR__, 3));
 $topURL = basename($_SERVER['REQUEST_URI']);
@@ -13,12 +7,17 @@ if ($topURL !== 'private' && !preg_match("/^\_.*$/", $topURL)) {
         if (!preg_match("/^\..*$/", $_page) && is_dir(dirname(__DIR__, 3). DIRECTORY_SEPARATOR .$_page)) {
             if (stripos($_page, $topURL) === 0) {
                 if (is_dir(dirname(__DIR__, 3). DIRECTORY_SEPARATOR. $_page)) {
-                    header('Location:https://'. $_SERVER['SERVER_NAME']. '/'. $_page);
+                    header('Location:https://'.$_SERVER['SERVER_NAME'].'/'.$_page);
                     exit;
                 }
             }
         }
     }
 }
+?>
+<!DOCTYPE html>
+<?php
+// 初期設定を記述
+$homepageTitle = htmlspecialchars(basename(__DIR__));
 http_response_code(404);
 require_once dirname(__DIR__). '/common/Layout/layout.php';


### PR DESCRIPTION
404ページに遷移したときに、
公開側に対象のURLのページがある場合は自動で遷移するように改修していたが、本番サーバで真っ白になってしまっていたため修正。
・<!DOCTYPE html>がheader関数よりも前に会ったことが原因
・ローカルではエラーにならなかったため発見が遅れた