### PR TITLE
BOKKUN-60 【管理側 全般】システムエラーになることがある

### DIFF
--- a/private/secure.php
+++ b/private/secure.php
@@ -41,7 +41,7 @@ $mode = 'movePage';
 
 </html>
 <?php
-if (!empty($post)) {
+if (!empty($post) && !empty($post['id']) && !empty($post['pass'])) {
     $adminAuth = ($post['id'] === 'admin' && password_verify($post['pass'], password_hash(LOGIN_PASSWORD, PASSWORD_DEFAULT)));
 } else {
     $adminAuth = null;
@@ -63,6 +63,10 @@ if ($moveURL[2] === 'secure.php' || $moveURL[2] === 'reset.php') {
 $movePage = implode('/', $moveURL);
 
 $session->WriteArray('admin', 'movePage', $url . $movePage);
+
+if (!isset($adminSession['movePage'])) {
+    $adminSession['movePage'] = $session->Read('admin')['movePage'];
+}
 
 if ((!($adminAuth))) {
     if (!empty($post)) {


### PR DESCRIPTION
期間を開けたりして管理側にアクセスした際、
ID/PW入力後にFatalエラーになることがある。
(リロードするとログインできる)

セッションが切れた状態で、必要なセッション変数を参照しようとしているからかと思われる。