### PR TITLE
BOKKUN-82 【管理側 全般|smarty周り】PHP周りの関数を使っている箇所でエラー

### DIFF
--- a/private/create/index.tpl
+++ b/private/create/index.tpl
@@ -19,8 +19,6 @@
         <h2>削除・複製</h2></div>
     {* <div><span><input type='checkbox'' name='all-copy' value='true' />すべてコピーする</span></div> *}
     <select name='select'>
-      {$count=0}
-      {$max=count($dir)}
       {foreach from=$dir item=item_name}
               <option value='{$item_name}' >{$item_name}</option>
       {/foreach}

--- a/private/edit/design.php
+++ b/private/edit/design.php
@@ -26,8 +26,13 @@ $editSrcToken->set();
 
 $dir = array_merge($dir, scandir('../../'));
 
+// dirファイルを調整
 foreach ($dir as $_key => $_dir) {
-    if (preg_match("/public$|private$|common$|custom.*$|template.*$|\..*$/", $_dir)) {
+    if (
+            preg_match("/public$|private$|common$|custom.*$|template.*$|\..*$/", $_dir)
+            || preg_match("/^.$/", $_dir)
+            || preg_match("/^..$/", $_dir)
+        ) {
         unset($dir[$_key]);
     }
 }

--- a/private/edit/index.tpl
+++ b/private/edit/index.tpl
@@ -1,12 +1,8 @@
 <form action='./{$base}/server.php' method='POST'>
     <div><p2>編集</p2></div>
     <select name='select'>
-      {$count=0}
-      {$max=count($dir)}
       {foreach from=$dir item=item_name}
-        {if mb_strpos($item_name, '.')!==0 && mb_strpos($item_name, 'template')!==0 && mb_strpos($item_name, 'common')!==0&& mb_strpos($item_name, 'index.php')!==0&& mb_strpos($item_name, 'client')!==0}
-              <option value='{$item_name}' >{$item_name}</option>
-          {/if}
+          <option value='{$item_name}' >{$item_name}</option>
       {/foreach}
     </select>
     <select class='select_directory' id='select_directory' name='select_directory'></select>

--- a/private/log/access/index.tpl
+++ b/private/log/access/index.tpl
@@ -1,12 +1,8 @@
 <form action='./{$base}/server.php' method='POST'>
     <div><p2><h3>アクセスログ選択</h3></p2></div>
     <select class='set_log' id='access' name='access_log'>
-      {$count=0}
-      {$max=count($dir)}
       {foreach from=$dir item=item_name}
-        {if mb_strpos($item_name, '.')!==0 && mb_strpos($item_name, '..')!==0}
-              <option value='{$item_name}' >{$item_name}</option>
-          {/if}
+          <option value='{$item_name}' >{$item_name}</option>
       {/foreach}
     </select>
 

--- a/private/log/error/design.php
+++ b/private/log/error/design.php
@@ -26,6 +26,16 @@ $dirPath = rtrim(dirname(__DIR__, 5), "\\") . createClient('log');
 $dir = ["---" => "---"];
 $dir = array_merge($dir, scandir($dirPath));
 
+// dirファイルを調整
+foreach ($dir as $_key => $_dir) {
+    if (
+            preg_match("/^.$/", $_dir)
+            || preg_match("/^..$/", $_dir)
+        ) {
+        unset($dir[$_key]);
+    }
+}
+
 $smarty->assign('base', basename(__DIR__) . '/subdirectory');
 $smarty->assign('dir_path', $dirPath);
 $smarty->assign('dir', $dir);

--- a/private/log/error/index.tpl
+++ b/private/log/error/index.tpl
@@ -1,12 +1,8 @@
 <form action='./{$base}/server.php' method='POST'>
     <div><p2><h3>エラーログ選択</h3></p2></div>
     <select class='set_log' id='error' name='error_log'>
-      {$count=0}
-      {$max=count($dir)}
       {foreach from=$dir item=item_name}
-        {if mb_strpos($item_name, '.')!==0 && mb_strpos($item_name, '..')!==0}
-              <option value='{$item_name}' >{$item_name}</option>
-          {/if}
+          <option value='{$item_name}' >{$item_name}</option>
       {/foreach}
     </select>
     <select class='select_log' id='error_src' name='select_log'>


### PR DESCRIPTION
smartyをバージョンアップしたところ、PHP周りの関数を使っている箇所でエラーが出るようになった。
テンプレート及びテンプレート読み込み前のロジックを変えることで対応。