### PR TITLE
BOKKUN-84 【全般|smarty】バージョン4からバージョン5へ更新

### DIFF
--- a/private/Sample/design_tpl.php
+++ b/private/Sample/design_tpl.php
@@ -1,11 +1,14 @@
 <!-- デザイン用ファイル (PHPで処理を記述)-->
 <?php
 
+use \Smarty\Smarty;
+
 $smarty = new Smarty();
-$smarty->template_dir = './subdirectory/templates/';
-$smarty->compile_dir  = './subdirectory/templates_c/';
-$smarty->config_dir   = './subdirectory/configs/';
-$smarty->cache_dir    = './subdirectory/cache/';
+
+$smarty->setTemplateDir('./subdirectory/smarty/templates/');
+$smarty->setCompileDir('./subdirectory/smarty/templates_c/');
+$smarty->setConfigDir('./subdirectory/smarty/configs/');
+$smarty->setCacheDir('./subdirectory/smarty/cache/');
 
 $smarty->assign('name', 'guest');
 $smarty->display('index.tpl');


### PR DESCRIPTION
管理側からページ作成するときのコピー元のソースが反映されていなかったので修正。