### PR TITLE
ファイル名の先頭の大文字・小文字を修正

### DIFF
--- a/private/image/subdirectory/ajax/server.php
+++ b/private/image/subdirectory/ajax/server.php
@@ -6,7 +6,7 @@ define("DS", DIRECTORY_SEPARATOR);
 require_once dirname(__DIR__, 3) . DS . "common" . DS . "ajax-require.php";
 $includePath = new \Path(getcwd());
 $includePath->setPathEnd();
-$includePath->add('include.php');
+$includePath->add('Include.php');
 require_once $includePath->get();
 includeFiles(__DIR__. '/');
 includeFiles(dirname(__DIR__). '/');

--- a/private/image/subdirectory/notAutoInclude/component/require.php
+++ b/private/image/subdirectory/notAutoInclude/component/require.php
@@ -54,7 +54,7 @@ $privatepathList->methodPath('addArray', ['common', 'Token.php']);
 
 // ファイル読み込み
 $privatepathList->setKey('include');
-$privatepathList->methodPath('addArray', ['common', 'include.php']);
+$privatepathList->methodPath('addArray', ['common', 'Include.php']);
 
 // UA
 $privatepathList->setKey('ua');


### PR DESCRIPTION
Linuxだとファイルの大文字・小文字が区別されるため、読み込めない事態になっていたため修正。