### PR TITLE
画像投稿・画像削除ページで勝手にログアウトされたり選択されたページから変わってしまう現象の修正

### DIFF
--- a/private/image/delete/subdirectory/notAutoInclude/server.php
+++ b/private/image/delete/subdirectory/notAutoInclude/server.php
@@ -1,5 +1,13 @@
 <?php
 
+if (!isset($_SERVER['HTTP_REFERER'])) {
+    $statusCode = 400;
+    chdir(dirname(__DIR__, 5). "/common/error/{$statusCode}");
+    require_once 'index.php';
+    http_response_code($statusCode);
+    return false;
+}
+
 require_once __DIR__ . '/component/require.php';
 require_once dirname(__DIR__) . '/File.php';
 
@@ -72,7 +80,7 @@ if (!empty($mode)) {
                 }
             } else {
                 // 削除対象が選択されていない場合
-                $session->write('delete-page-notice', NOT_FOUND_PERMANENT_DLETE_OR_RESTORE_IMAGE, 'Delete');
+                $session->write('delete-page-notice', NOT_FOUND_PERMANENT_DLETE_OR_RESTORE_IMAGE);
             }
         } elseif (isset($posts['restore'])) {
             // 復元の場合
@@ -136,7 +144,7 @@ if (!empty($mode)) {
         $imagePageName = getImagePageName();
 
         // 対象の画像名を取得
-        $imageFile = $mode = Private\Important\Setting::getQuery('image');
+        $imageFile = Private\Important\Setting::getQuery('image');
 
         // 画像ファイルのパスを取得（GETパラメータから）
         $imgPath = new \Path(PUBLIC_DIR_LIST['image']);
@@ -161,13 +169,14 @@ if (!empty($mode)) {
     }
 }
 
-if(isset($posts['delete'])) {
+if(isset($posts['restore']) || isset($posts['delete'])) {
+    // セッション更新
     if (session_status() !== PHP_SESSION_ACTIVE) {
         session_start();
     }
     session_regenerate_id();
-    $session->write('delete-token', sha1(session_id()));
-    // $session->delete();
+    $session->write('delete-select-token', sha1(session_id()));
+    $session->write('delete-view-token', sha1(session_id()));
 }
 
 if ($mode === 'edit') {

--- a/private/image/subdirectory/notAutoInclude/server.php
+++ b/private/image/subdirectory/notAutoInclude/server.php
@@ -18,7 +18,7 @@ if (!empty($mode) && $mode === 'edit') {
     // view-tokenチェック
     $viewToken = new Private\Important\Token('view-token', $session);
     if ($viewToken->check() === false) {
-        $session->write('notice', '不正な遷移です。もう一度操作してください。', 'Delete');
+        $session->write('notice', '不正な遷移です。もう一度操作してください。');
         $setting = new Private\Important\Setting();
         header('Location:' . $setting->getUrl('root', $str));
         exit;
@@ -57,7 +57,7 @@ if (!empty($mode) && $mode === 'edit') {
                     $noticeWord .= "・". $imageNameArray[$_key]. SUCCESS_DELETE_IMAGE_DETAIL;
                     $noticeWord .= nl2br("\n");
                 }
-                $session->write('success', $noticeWord, 'Delete');
+                $session->write('success', $noticeWord);
             }
 
             // 削除失敗した画像について
@@ -69,11 +69,11 @@ if (!empty($mode) && $mode === 'edit') {
                     $noticeWord .= "・". $imageNameArray[$_key]. FAIL_DELETE_IMAGE_DETAIL;
                     $noticeWord .= nl2br("\n");
                 }
-                $session->write('notice', $noticeWord, 'Delete');
+                $session->write('notice', $noticeWord);
             }
         } else {
             // 削除対象が選択されていない場合
-            $session->write('notice', NOT_FOUND_DLETE_IMAGE, 'Delete');
+            $session->write('notice', NOT_FOUND_DLETE_IMAGE);
         }
     } elseif (isset($posts['copy'])) {
         // コピーの場合
@@ -127,7 +127,7 @@ if (!empty($mode) && $mode === 'edit') {
         }
     } else {
         // 削除・複製以外の場合(不正値)
-        $session->write('notice', '不正な遷移です。もう一度操作してください。', 'Delete');
+        $session->write('notice', '不正な遷移です。もう一度操作してください。');
         $url = new Private\Important\Setting();
         header('Location:' . $url->getUrl('root', $str));
         exit;
@@ -136,7 +136,7 @@ if (!empty($mode) && $mode === 'edit') {
     // upload-tokenチェック
     $uploadToken = new Private\Important\Token('upload-token', $session);
     if ($uploadToken->check() === false) {
-        $session->write('notice', '不正な遷移です。もう一度操作してください。', 'Delete');
+        $session->write('notice', '不正な遷移です。もう一度操作してください。');
         $url = new Private\Important\Setting();
         header('Location:' . $url->getUrl('root', $str));
         exit;


### PR DESCRIPTION
セッション削除で既存の設定が消されてしまっていたので、不要なセッション削除処理を削除。